### PR TITLE
Fix python dateutil

### DIFF
--- a/de.ifw_dresden.nagstamon.appdata.xml
+++ b/de.ifw_dresden.nagstamon.appdata.xml
@@ -21,16 +21,21 @@
     <url type="bugtracker">https://github.com/HenriWahl/Nagstamon/issues</url>
 	<launchable type="desktop-id">de.ifw_dresden.nagstamon.desktop</launchable>
 	<releases>
-		<release version="3.4.1" date="2020-01-26">
+		<release version="3.6.0" date="2021-04-06">
 			<description>
 				<ul>
-                                        <li>Centreon fix for acknowledgement when using autologin key</li>
-					<li>IcingaWeb2 fix support older setups</li>
-                                        <li>fix popup in systray mode on Windows</li>
-                                        <li>improved mode switching</li>
-                                        <li>better support for high resolution displays</li>
-                                        <li>build support for Python 3.8</li>
-                                        <li>improved Windows installer</li>
+          <li>added Prometheus support</li>
+          <li>added SensuGo support</li>
+          <li>added support for SOCKS5 proxy</li>
+          <li>added display of macOS version</li>
+          <li>update for Centreon 20.10</li>
+          <li>fixes for Zabbix</li>
+          <li>fix for IcingaWeb2</li>
+          <li>fix for Nagios/Icinga login with invalid credentials</li>
+          <li>fixes Thruk login</li>
+          <li>fixes context menu bug</li>
+          <li>fix for HighDPI</li>
+          <li>fix for distro detection</li>
 				</ul>
 			</description>
 		</release>

--- a/de.ifw_dresden.nagstamon.yml
+++ b/de.ifw_dresden.nagstamon.yml
@@ -20,6 +20,7 @@ modules:
   - modules/python3-requests.yml
   - modules/python3-keyring.yml
   - modules/python3-lxml.yml
+  - modules/python3-dateutil.yml
   - modules/python3-psutil.yml
   - modules/PyQt5-sip.yml
   - modules/PyQt5.yml

--- a/modules/PyQt5.yml
+++ b/modules/PyQt5.yml
@@ -46,8 +46,8 @@ build-options:
         - --enable=QtMultimedia
 sources:
   - type: archive
-    url: https://www.riverbankcomputing.com/static/Downloads/PyQt5/PyQt5-5.15.2.dev2010041344.tar.gz
-    sha256: 25153398487b652b4b0737e0a348dfd9a077c5865cfeb79b02470efa597cfe8e
+    url: https://files.pythonhosted.org/packages/28/6c/640e3f5c734c296a7193079a86842a789edb7988dca39eab44579088a1d1/PyQt5-5.15.2.tar.gz
+    sha256: 372b08dc9321d1201e4690182697c5e7ffb2e0770e6b4a45519025134b12e4fc
   - type: script
     commands:
       - processed=`sed -e 's|prefix|sysroot|' <<< $@`

--- a/modules/python3-dateutil.yml
+++ b/modules/python3-dateutil.yml
@@ -1,0 +1,12 @@
+name: python3-dateutil
+buildsystem: simple
+build-commands:
+  - pip3 install --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST}
+    python-dateutil
+sources:
+  - type: file
+    url: https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
+    sha256: 75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a
+  - type: file
+    url: https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
+    sha256: 8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced


### PR DESCRIPTION
Core reason for pull requests is missing python-dateutil dependency: 
```bash
$ flatpak run de.ifw_dresden.nagstamon
Traceback (most recent call last):
  File "/app/bin/nagstamon.py", line 45, in <module>
    from Nagstamon.QUI import (APP,
  File "/app/lib/python3.7/site-packages/Nagstamon/QUI/__init__.py", line 61, in <module>
    from Nagstamon.Servers import (SERVER_TYPES,
  File "/app/lib/python3.7/site-packages/Nagstamon/Servers/__init__.py", line 53, in <module>
    from Nagstamon.Servers.Prometheus import PrometheusServer
  File "/app/lib/python3.7/site-packages/Nagstamon/Servers/Prometheus.py", line 56, in <module>
    import dateutil.parser
ModuleNotFoundError: No module named 'dateutil'
```
Also bumped version to latest tag (3.6.0) and corrected download URL for PyQt5-5.15.2 due to 404 error.